### PR TITLE
Tomer/implement auth with cognito and deploy stage

### DIFF
--- a/CTFd/api/v1/challenges.py
+++ b/CTFd/api/v1/challenges.py
@@ -54,7 +54,7 @@ from CTFd.utils.user import (
     is_admin,
 )
 from CTFd.utils.aws.challenges import send_deployment_request
-#from CTFd.utils.aws.user import update_user_attributes
+from CTFd.utils.security.auth import update_user_info
 challenges_namespace = Namespace(
     "challenges", description="Endpoint to retrieve Challenges"
 )
@@ -424,9 +424,7 @@ class Challenge(Resource):
 
         
         challenge_secrets  = json.dumps(send_deployment_request(challenge_id, session['tokens']["IdToken"]))
-        #update_user_attributes(session['tokens']["AccessToken"], {'active_c': challenge_id})
-        print('*******')
-        print(challenge_secrets)
+        update_user_info({'custom:active_c': challenge_id})
         response["secrets"] = challenge_secrets
         response["solves"] = solve_count
         response["solved_by_me"] = solved_by_user

--- a/CTFd/config.ini
+++ b/CTFd/config.ini
@@ -292,15 +292,15 @@ SAFE_MODE =
 [oauth]
 # OAUTH_CLIENT_ID
 #OAUTH_CLIENT_ID =1bga42tu4tb98dn55uta5trh6b
-OAUTH_CLIENT_ID = 662u8qsf0glj1iberfoq3vhl22
+OAUTH_CLIENT_ID = 1p1hegscabr39jp23nb99phshb
 #OAUTH_CLIENT_SECRET = os709cvi0dmjcvlensjerg01m0u4n1oe170kqhsack6a145gi81
-OAUTH_CLIENT_SECRET = 1sllngr563vaign6m0a9achikfmjbbt0odtc3dqn1ngrnhqhhh8g
+OAUTH_CLIENT_SECRET = 1eh904icnoa83ghgcnf6jq7cul94lplqrjj4nloqfm5fk75vqm3m
 OAUTH_API_ENDPOINT = https://cognito-idp.il-central-1.amazonaws.com/oauth2/token
 OAUTH_REDIRECT_URI = https://d88f-89-139-36-16.ngrok-free.app/redirect
 
 [aws]
 COGNITO_REGION = il-central-1
-COGNITO_USER_POOL_ID = il-central-1_01p1HE770
+COGNITO_USER_POOL_ID = il-central-1_PVNJ3FX3o
 
 [newname]
 DEPLOY_SERVICE_ADDRESS = http://51.17.21.133:8888

--- a/CTFd/utils/aws/auth_helpers.py
+++ b/CTFd/utils/aws/auth_helpers.py
@@ -32,8 +32,6 @@ def cognito_registration(user):
         "Password": user['password'],
         "UserAttributes": [
             {"Name": "email", "Value": user['email']},
-            { "Name": "name", "Value": "Sefi Ovadia" }
-
         ],
     }
     url = 'https://ctf.auth.il-central-1.amazoncognito.com'
@@ -46,6 +44,8 @@ def cognito_registration(user):
         print(response)
         return {'success': True, 'message': 'User registered successfully!', 'data': response}
     except cognito.exceptions.ClientError as e:
+        print('@@@@')
+        print(e)
         print(f"Error during user registration: {e.response['Error']['Message']}")
         return {'success': False, 'message': e.response['Error']['Message']}
 

--- a/CTFd/utils/aws/user.py
+++ b/CTFd/utils/aws/user.py
@@ -1,0 +1,22 @@
+from CTFd.utils.aws.constants import cognito
+#this function accepts key-value dictionary of user attributes and updates the user attributes in auth provider
+def update_user_attributes(access_token, attributes):
+    attributes_to_update = []
+    for key, value in attributes.items():
+        attributes_to_update.append({
+            'Name': key,
+            'Value': value
+        })
+    payload = {
+        "UserAttributes": [{'Name': 'custom:active_c', 'Value': '1'}],
+        "AccessToken": access_token,
+    }
+    try:
+        response = cognito.update_user_attributes(**payload)
+        print("User attributes updated successfully!")
+        print(response)
+        return {'success': True, 'message': 'User attributes updated successfully!', 'data': response}
+    except cognito.exceptions.ClientError as e:
+        print(e)
+        print(f"Error during User attributes update process: {e.response['Error']['Message']}")
+        return {'success': False, 'message': e.response['Error']['Message']}

--- a/CTFd/utils/security/auth.py
+++ b/CTFd/utils/security/auth.py
@@ -8,7 +8,7 @@ from CTFd.utils.encoding import hexencode
 from CTFd.utils.security.csrf import generate_nonce
 from CTFd.utils.security.signing import hmac
 from CTFd.utils.aws.auth_helpers import cognito_login, validate_cognito_token, uuid_to_number
-
+from CTFd.utils.aws.user import update_user_attributes
 from flask import redirect
 
 def login_user_new(username, password, registration_data = None):
@@ -88,3 +88,6 @@ def lookup_user_token(token):
     else:
         raise UserNotFoundException
     return None
+
+def update_user_info(attributes_list):  
+    return update_user_attributes(session['tokens']["AccessToken"], attributes_list)    

--- a/CTFd/utils/user/__init__.py
+++ b/CTFd/utils/user/__init__.py
@@ -11,6 +11,7 @@ from CTFd.constants.teams import TeamAttrs
 from CTFd.constants.users import UserAttrs
 from CTFd.models import Fails, Teams, Tracking, Users, db
 from CTFd.utils import get_config
+from CTFd.utils.aws.auth_helpers import validate_cognito_token
 from CTFd.utils.security.auth import logout_user
 from CTFd.utils.security.signing import hmac
 
@@ -128,9 +129,17 @@ def get_current_user_type(fallback=None):
     else:
         return fallback
 
+@cache.memoize(timeout=1)
+def validate_token(token):
+    return validate_cognito_token(token)
+
 
 def authed():
-    return bool(session.get("id", False))
+    #TBD -> implement refresh token flow
+    token_validation_result = validate_token(session['tokens']['IdToken'])
+    if token_validation_result['success'] and bool(session.get("id", False)):
+        return True
+    return 
 
 
 def is_admin():


### PR DESCRIPTION
This PR contains the work of both features - authentication with cognito into ctfd & deploying a stage via the deploy_service Interface over basic UI flow.
IMPORTANT NOTE - admin panel restriction disabled in order to test the functionality - we will bring them back in the future.

https://trello.com/c/wXoTnni4/25-implement-cognito-authentication-into-ctfd-backend
https://trello.com/c/jalZGC1j/31-implement-cognito-authentication-into-ctfd-frontend
https://trello.com/c/s4LhecYP/32-enable-user-stage-deploy-thru-ctfd-deploy-service